### PR TITLE
added 1 to all can ids

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -34,12 +34,12 @@ public final class Constants {
     public static final int RIGHT_STICK_BUTTON = 10;
 
     // Motors
-    public static final int HOOK_MOTOR = 6;
-    public static final int BAR_MOTOR = 5;
-    public static final int LEFT_FRONT_MOTOR = 3;
-    public static final int LEFT_REAR_MOTOR = 4;
-    public static final int RIGHT_FRONT_MOTOR = 2;
-    public static final int RIGHT_REAR_MOTOR = 1;
+    public static final int HOOK_MOTOR = 7;
+    public static final int BAR_MOTOR = 6;
+    public static final int LEFT_FRONT_MOTOR = 4;
+    public static final int LEFT_REAR_MOTOR = 5;
+    public static final int RIGHT_FRONT_MOTOR = 3;
+    public static final int RIGHT_REAR_MOTOR = 2;
 
     // Positions
     public static final int MAX_ARM_POS = 98;


### PR DESCRIPTION
closes #30 

Any code before this update will not function anymore. The CAN IDs on each robot have been changed so that they match each other, however "1" was occupied by a motor and the power distribution panel on the shooter robot, so I have added one to each motor's CAN ID so that the power distribution panel doesn't cause any conflicts.